### PR TITLE
Readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@ was used in the following papers (alse see [citations](#citations)):
 
 - [On the state of the art of evaluation in neural language models](https://arxiv.org/abs/1707.05589)
 
-  See [./experiment/on-the-state/README.md](./experiment/on-the-state/README.md)
+  See [./lamb/experiment/on-the-state/README.md](./lamb/experiment/on-the-state/README.md)
   for more.
 
 - [Pushing the bounds of dropout](https://arxiv.org/abs/1805.09208)
 
   See
-  [./experiment/pushing-the-bounds/README.md](./experiment/pushing-the-bounds/README.md)
+  [./lamb/experiment/pushing-the-bounds/README.md](./lamb/experiment/pushing-the-bounds/README.md)
   for more.
 
 - [Mogrifier LSTM](https://arxiv.org/abs/1909.01792)
 
-  See [./experiment/mogrifier/README.md](./experiment/mogrifier/README.md) for
+  See [./lamb/experiment/mogrifier/README.md](./lamb/experiment/mogrifier/README.md) for
   more.
 
 <a name="overview"></a>

--- a/README.md
+++ b/README.md
@@ -72,11 +72,7 @@ For example:
 
     conda create -n tfp3.7 python=3.7 numpy scipy
     conda activate tfp3.7
-    conda install cudatoolkit
-    conda install cudnn
-    conda install tensorflow-gpu=1.15
-    conda install tensorflow-probability-gpu=1.15
-    conda install tensorflow-probability
+    conda install cudatoolkit cudnn tensorflow-gpu=1.15 tensorflow-probability
     pip install -e <path-to-git-checkout>
 
 <a name="reference"></a>

--- a/lamb/experiment/mogrifier/README.md
+++ b/lamb/experiment/mogrifier/README.md
@@ -2,7 +2,7 @@ This directory contains saved configuration files for tuned models from the
 [Mogrifier LSTM](https://arxiv.org/abs/1909.01792) paper. Model weights are not
 included.
 
-Don't forget to [set up the data](../../README.md).
+Don't forget to [set up the data](../../../README.md).
 
 For example, to train a Mogrifier LSTM with 24M parameters on PTB with tuned
 hyperparameters (see the paper above):

--- a/lamb/experiment/on-the-state/README.md
+++ b/lamb/experiment/on-the-state/README.md
@@ -2,7 +2,7 @@ This directory contains saved configuration files for tuned models from the [On
 the state of the art of evaluation in neural language
 models](https://arxiv.org/abs/1707.05589) paper. Model weights are not included.
 
-Don't forget to [set up the data](../../README.md).
+Don't forget to [set up the data](../../../README.md).
 
 To train the 1 layer LSTM model of 10m weights on PTB with tuned hyperparameters
 (see the paper above):


### PR DESCRIPTION
<offtopic>
Got here through the Mogrifier paper. Great read, and the 'case for small scale' is really refreshing. I am surprised to see no activity here.
</offtopic>

Updated a few broken links in READMEs

Also, installing `tensorflow-probability-gpu=1.15` did not work (package not found), but I have found some claims that it is now sufficient to install `tensorflow-probability`. Training seems to work (at least for a few "turns"), without the `-gpu`.