### PR TITLE
Updating package setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ For example:
     conda install cudatoolkit
     conda install cudnn
     conda install tensorflow-gpu=1.15
-    conda install tensorflow-probability-gpu=1.15
-    conda install tensorflow-probability
+    pip install --upgrade --user "tensorflow<2" "tensorflow_probability<0.9"
+    pip install dm-sonnet==1.36
     pip install -e <path-to-git-checkout>
 
 <a name="reference"></a>


### PR DESCRIPTION
1. The tensorflow-probability package no longer has separate GPU versions, and has been updated for tensorflow 2. This change gets a suitable version.
2. Sonnet was previously missing from the instructions. The specified version is the last version before it was updated for tensorflow 2.